### PR TITLE
尝试通过添加if: always()强制call-OfficialDocSubmoduleSync不被Skipped

### DIFF
--- a/.github/workflows/DoxygenAutoDocSyncDoxygen.yml
+++ b/.github/workflows/DoxygenAutoDocSyncDoxygen.yml
@@ -88,7 +88,8 @@ jobs:
       docRepoSecret: ${{ secrets.ORG_DOC_SYNC_SECRET }}
 
   call-OfficialDocSubmoduleSync:
-    needs: [prepare,call-doxygen-auto-code-to-doc]
+    needs: [prepare, call-doxygen-auto-code-to-doc]
+    if: always()
     uses: 701Enti/SEVETEST30/.github/workflows/OfficialDocSubmoduleSync.yml@master
     with:
       UPDATE_BRANCH: ${{ needs.prepare.outputs.BRANCH_NAME }}


### PR DESCRIPTION
1.在DoxygenAutoDocSyncDoxygen优化call-OfficialDocSubmoduleSync的needs字段空格
2.在DoxygenAutoDocSyncDoxygen尝试通过添加if: always()强制call-OfficialDocSubmoduleSync不被Skipped