### PR TITLE
OfficialDocSubmoduleSync的Create PR删除无效的merge参数+更新子模块使用--force参数

### DIFF
--- a/.github/workflows/OfficialDocSubmoduleSync.yml
+++ b/.github/workflows/OfficialDocSubmoduleSync.yml
@@ -128,7 +128,6 @@ jobs:
           title: "(New Robot branch)Update documentation ${{ needs.information_collect.outputs.docRepoName }} |  ${{ steps.push_changes.outputs.NEW_DOC_COMMIT_SHA }}"
           body: "The pull&request is created by ${{ github.workflow }} [run_id: - ${{ github.run_id }}]"
           labels: automation
-          merge: false  
 
   exists_true:
     runs-on: ubuntu-latest
@@ -150,7 +149,7 @@ jobs:
 
       - name: Update Submodule
         run: |
-          git submodule update --remote --merge -- "docs/official/repo_doc/${{ needs.information_collect.outputs.docRepoName }}"
+          git submodule update --remote --force -- "docs/official/repo_doc/${{ needs.information_collect.outputs.docRepoName }}"
 
       - name: Push changes to code repository
         id: push_changes
@@ -180,4 +179,3 @@ jobs:
           title: "(New Robot branch)Update documentation ${{ needs.information_collect.outputs.docRepoName }} |  ${{ steps.push_changes.outputs.NEW_DOC_COMMIT_SHA }}"
           body: "The pull&request is created by ${{ github.workflow }} [run_id: - ${{ github.run_id }}]"
           labels: automation
-          merge: false  


### PR DESCRIPTION
OfficialDocSubmoduleSync中
1.Create PR删除无效的merge参数
2.更新子模块使用--force参数而不是--merge