### PR TITLE
OfficialDocSubmoduleSync的Create PR中环境变量GITHUB_TOKEN重命名为GH_TOKEN

### DIFF
--- a/.github/workflows/OfficialDocSubmoduleSync.yml
+++ b/.github/workflows/OfficialDocSubmoduleSync.yml
@@ -136,7 +136,7 @@ jobs:
 
       - name: Create PR 
         env:
-          GITHUB_TOKEN: ${{ secrets.ORG_DOC_SYNC_SECRET }}
+          GH_TOKEN: ${{ secrets.ORG_DOC_SYNC_SECRET }}
           DOC_REPO_NAME: ${{ needs.information_collect.outputs.docRepoName }}
           ROBOT_UPDATE_BRANCH: ${{ needs.information_collect.outputs.ROBOT_UPDATE_BRANCH }}
           UPDATE_BRANCH: ${{ needs.information_collect.outputs.UPDATE_BRANCH }}
@@ -208,7 +208,7 @@ jobs:
 
       - name: Create PR 
         env:
-          GITHUB_TOKEN: ${{ secrets.ORG_DOC_SYNC_SECRET }}
+          GH_TOKEN: ${{ secrets.ORG_DOC_SYNC_SECRET }}
           DOC_REPO_NAME: ${{ needs.information_collect.outputs.docRepoName }}
           ROBOT_UPDATE_BRANCH: ${{ needs.information_collect.outputs.ROBOT_UPDATE_BRANCH }}
           UPDATE_BRANCH: ${{ needs.information_collect.outputs.UPDATE_BRANCH }}


### PR DESCRIPTION
GitHub CLI令牌应该使用GH_TOKEN注入